### PR TITLE
feat!: allow arbitrary filesystem for `fromDirectory`

### DIFF
--- a/src/Distree.ts
+++ b/src/Distree.ts
@@ -85,13 +85,18 @@ const iterate = function* <T>(
 const rec = <T>(
 	content: DistreeInternal.Initializer<T>,
 	parent: DistreeInternal<T> | undefined,
+	memo: Map<DistreeInternal.Initializer<T>, DistreeInternal<T>> = new Map(),
 ): DistreeInternal<T> => {
+	const existing = memo.get(content)
+	if (existing) return existing
+
 	const distree = new Proxy<DistreeInternal<T>>(Object.create(null) as DistreeInternal<T>, {
 		get: (target, key, receiver) => {
 			if (typeof key === "string") return resolve(target, key)
 			else return Reflect.get(target, key, receiver)
 		},
 	})
+	memo.set(content, distree)
 
 	// Populate as a distree
 	Object.defineProperties(distree, {
@@ -109,7 +114,7 @@ const rec = <T>(
 	// Copy contents into the new distree
 	for (const [key, value] of Object.entries(content)) {
 		if (key.search(/\/+/) !== -1) throw new Error(`Keys are not allowed to contain slashes: ${key}`)
-		if (isPlainObject(value)) distree[key] = rec(value, distree)
+		if (isPlainObject(value)) distree[key] = rec(value, distree, memo)
 		else distree[key] = value
 	}
 

--- a/src/fromDirectory.ts
+++ b/src/fromDirectory.ts
@@ -5,58 +5,91 @@ import from from "./from.ts"
 import transform from "./transform.ts"
 import transformAsync from "./transformAsync.ts"
 
-const rec = async (path: string): Promise<typeof content> => {
-	const { lstat } = await import("https://esm.sh/jsr/@cross/fs@0.1.11/stat")
-	const { readdir } = await import("https://esm.sh/jsr/@cross/fs@0.1.11/ops")
-	const { resolve } = await import("https://esm.sh/jsr/@std/path@1.0.8/resolve")
-	const content: { [key: string]: typeof content | string } = Object.create(null)
-	for (const pathItemRelative of await readdir(path)) {
-		const pathItem = resolve(path, pathItemRelative)
-		const item = await lstat(pathItem, {})
-		if (item.isFile()) {
-			const [key, value] = [pathItemRelative, pathItem]
-			content[key] = value
-		} else if (item.isDirectory()) {
-			const [key, value] = [pathItemRelative, await rec(pathItem)]
-			content[key] = value
-		} else {
-			// TODO: handle symlinks (breaking change)
-		}
+namespace fromDirectory {
+	export type Ls = (url: URL) => AsyncIterable<LsEntry>
+	export type LsEntry = {
+		type: "file" | "directory"
+		name: string
+		url: URL
 	}
-
-	Object.setPrototypeOf(content, Object.prototype)
-	return content
 }
 
-const fromDirectory: {
-	(path: string): Promise<Distree<string>>
-	(path: string, filter: string | RegExp): Promise<Distree<string>>
-	<T>(
-		path: string,
-		transform: (value: string, path: string) => Promise<Distree.ItemInitializer<T>>,
-	): Promise<Distree<T>>
-} = async <
-	T,
-	F extends
-		| string
-		| RegExp
-		| undefined
-		| ((value: string, path: string) => Promise<Distree.ItemInitializer<T>>),
->(
-	path: string,
-	filter?: F,
-): Promise<Distree<F extends string | RegExp | undefined ? string : T>> => {
-	const distree = from(await rec(path)) as Distree<string>
-	return (
-		filter === undefined
-			? distree
-			: typeof filter === "function"
-				? await transformAsync(distree, filter)
-				: transform(distree, value => {
-						if (value.match(filter)) return value
-						else throw undefined
-					})
-	) as Distree<F extends string | RegExp | undefined ? string : T>
+type Directory = { [entry: string]: Directory | URL }
+
+const enumerateFilesRecursively = async (
+	url: URL,
+	ls: fromDirectory.Ls,
+	memo: Map<string, Directory> = new Map(),
+): Promise<Directory> => {
+	const existing = memo.get(url.href)
+	if (existing) return existing
+	const directory: Directory = Object.create(null)
+	memo.set(url.href, directory)
+	for await (const entry of ls(url)) {
+		console.log(`Processing ${entry.type} ${entry.url.href}`)
+		switch (entry.type) {
+			case "file":
+				{
+					directory[entry.name] = entry.url
+				}
+				break
+			case "directory":
+				{
+					const existing = memo.get(entry.url.href)
+					if (existing) directory[entry.name] = existing
+					else {
+						const subdirectory = await enumerateFilesRecursively(entry.url, ls, memo)
+						directory[entry.name] = subdirectory
+						memo.set(entry.url.href, subdirectory)
+					}
+				}
+				break
+		}
+	}
+	return directory
+}
+
+const lsDefault: fromDirectory.Ls = async function* (url) {
+	const { lstat, readdir, realpath } = await import("node:fs/promises")
+	for await (const name of await readdir(url)) {
+		let urlEntry = new URL(`${url.href}/${name}`)
+		let entry = await lstat(urlEntry)
+		while (entry.isSymbolicLink()) {
+			urlEntry = new URL(await realpath(urlEntry), urlEntry)
+			entry = await lstat(urlEntry)
+		}
+		const type = entry.isFile() ? "file" : entry.isDirectory() ? "directory" : undefined
+		if (!type) throw new Error(`Unknown entry type of \`${urlEntry.href}\``)
+		yield { url: urlEntry, type, name }
+	}
+}
+
+const fromDirectory = async <T = URL>(
+	url: URL,
+	options: {
+		filter?: string | RegExp | undefined
+		transformer?:
+			| ((
+					value: URL,
+					path: string,
+			  ) => Promise<Distree.ItemInitializer<T>> | Distree.ItemInitializer<T>)
+			| undefined
+		ls?: fromDirectory.Ls | undefined
+	} = {},
+): Promise<Distree<T>> => {
+	const { filter, transformer, ls } = options
+	const directory: Distree.Initializer<URL> = await enumerateFilesRecursively(url, ls ?? lsDefault)
+	const distreeRaw = from(directory)
+	const distreeFiltered = filter
+		? transform(distreeRaw, value => {
+				if (value.href.match(filter)) return value
+				else throw undefined
+			})
+		: distreeRaw
+	const distreeTransformed = transformer
+		? await transformAsync(distreeFiltered, transformer)
+		: distreeFiltered
+	return distreeTransformed as Distree<T>
 }
 
 export default fromDirectory

--- a/src/transformAsync.ts
+++ b/src/transformAsync.ts
@@ -15,7 +15,10 @@ import insert from "./insert.ts"
  */
 const transformAsync = async <T, U>(
 	distree: Distree<T>,
-	transformer: (value: T, path: string) => Promise<Distree.ItemInitializer<U>>,
+	transformer: (
+		value: T,
+		path: string,
+	) => Promise<Distree.ItemInitializer<U>> | Distree.ItemInitializer<U>,
 ): Promise<Distree<U>> => {
 	return (
 		await Promise.all(

--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -5,9 +5,15 @@
  * @internal
  */
 const isPlainObject = (value: unknown): value is object => {
-	return (
-		typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype
-	)
+	if (typeof value === "object" && value !== null) {
+		const prototype = Object.getPrototypeOf(value)
+		switch (prototype) {
+			case Object.prototype:
+			case null:
+				return true
+		}
+	}
+	return false
 }
 
 export { isPlainObject }

--- a/tests/from.test.ts
+++ b/tests/from.test.ts
@@ -40,7 +40,10 @@ Deno.test("prevent prototype pollution", async () => {
 	assertEquals({}.polluted, undefined)
 })
 
-Deno.test("reject non plain objects", async () => {
+Deno.test("rejects non plain objects", async () => {
 	assertThrows(() => from({ __proto__: { polluted: 0 } }))
-	assertThrows(() => from(Object.create(null)))
+})
+
+Deno.test("accepts null prototype objects", async () => {
+	from(Object.create(null))
 })

--- a/tests/fromDirectory.test.ts
+++ b/tests/fromDirectory.test.ts
@@ -2,23 +2,20 @@
 
 import { assertExists, assertEquals, assertFalse } from "@std/assert"
 import fromDirectory from "distree/fromDirectory.ts"
-import transform from "distree/transform.ts"
 
 Deno.test("fromDirectory", async () => {
-	const distree = await fromDirectory("../src", /Distree/)
+	const distree = await fromDirectory(new URL(import.meta.resolve("../src")), {
+		filter: /Distree/,
+	})
 	assertExists(distree["isDistree.ts"])
 	assertExists(distree["Distree.ts"])
 	assertFalse(distree["from.ts"])
 })
 
-Deno.test("prevent prototype pollution", async () => {
-	const distree = transform(await fromDirectory("fromDirectory"), () => ({ polluted: true }))
-
+Deno.test("handles recursive symbolic links", async () => {
+	const distree = await fromDirectory(new URL(import.meta.resolve("./fromDirectory")))
 	assertEquals(
-		Deno.inspect(distree),
-		`{\n  ['__proto__']: { polluted: true },\n  "Hello, World!": { polluted: true },\n  constructor: { prototype: { polluted: true } }\n}`,
+		distree["linkToParent/fromDirectory/linkToCurrent/__proto__"]?.href,
+		import.meta.resolve("./fromDirectory/__proto__"),
 	)
-
-	// @ts-expect-error: testing the prototype
-	assertEquals({}.polluted, undefined)
 })

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -16,3 +16,24 @@ Deno.test("transform", async () => {
 	const transformed = transform(distree, value => "quux")
 	assertEquals(transformed["foo/bar/baz"], "quux")
 })
+
+Deno.test("prevent prototype pollution", async () => {
+	const distree = transform(
+		from({
+			["__proto__"]: undefined,
+			"Hello, World!": undefined,
+			constructor: { prototype: undefined },
+		}),
+		() => ({
+			polluted: true,
+		}),
+	)
+
+	assertEquals(
+		Deno.inspect(distree),
+		`{\n  ['__proto__']: { polluted: true },\n  "Hello, World!": { polluted: true },\n  constructor: { prototype: { polluted: true } }\n}`,
+	)
+
+	// @ts-expect-error: testing the prototype
+	assertEquals({}.polluted, undefined)
+})


### PR DESCRIPTION
This change also allows symbolic links for `fromDirectory`, as well as cyclic references for `from`.